### PR TITLE
Flash merchants candu

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
+    ffi (1.11.1-java)
+    ffi (1.11.1-x64-mingw32)
+    ffi (1.11.1-x86-mingw32)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -74,8 +77,12 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
+    json (2.2.0-java)
     launchy (2.4.3)
       addressable (~> 2.3)
+    launchy (2.4.3-java)
+      addressable (~> 2.3)
+      spoon (~> 0.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -90,14 +97,27 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     nio4r (2.3.1)
+    nio4r (2.3.1-java)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.3-java)
+    nokogiri (1.10.3-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.3-x86-mingw32)
+      mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    pg (1.1.4-x64-mingw32)
+    pg (1.1.4-x86-mingw32)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry (0.12.2-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
     public_suffix (3.1.1)
     puma (3.12.1)
+    puma (3.12.1-java)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -165,6 +185,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    spoon (0.0.6)
+      ffi
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -174,9 +196,12 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2019.2)
+      tzinfo (>= 1.0.0)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     web-console (3.7.0)
@@ -186,12 +211,18 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
+    websocket-driver (0.6.5-java)
+      websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
+  java
   ruby
+  x64-mingw32
+  x86-mingw32
+  x86-mswin32
 
 DEPENDENCIES
   byebug
@@ -213,4 +244,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -21,11 +21,10 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    binding.pry
-    if !@merchant.update(merchant_params)
-      @merchant.errors.full_messages
+    if !@merchant.update(new_params)
+      flash[:error] = @merchant.errors.full_messages.join("")
     else
-      @merchant.update(merchant_params)
+      @merchant.update(new_params)
     end
     redirect_to "/merchants/#{@merchant.id}"
   end
@@ -41,8 +40,7 @@ class MerchantsController < ApplicationController
     params.permit(:name, :address, :city, :state, :zip)
   end
 
-
   def new_params
-    binding.pry
+    params.permit(:name, :address, :city, :state, :zip)
   end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -21,8 +21,8 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    if merchant_params.values.include?("")
-      flash[:bad_update] = "You are missing required fields"
+    if new_params.values.include?("")
+      @merchant.errors.full_messages
     else
       @merchant.update(merchant_params)
     end
@@ -39,4 +39,9 @@ class MerchantsController < ApplicationController
   def merchant_params
     params.permit(:name, :address, :city, :state, :zip)
   end
+
+
+    def new_params
+      binding.pry
+    end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -21,7 +21,11 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    @merchant.update(merchant_params)
+    if merchant_params.values.include?("")
+      flash[:bad_update] = "You are missing required fields"
+    else
+      @merchant.update(merchant_params)
+    end
     redirect_to "/merchants/#{@merchant.id}"
   end
 

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -11,8 +11,13 @@ class MerchantsController < ApplicationController
   end
 
   def create
-    Merchant.create(merchant_params)
-    redirect_to '/merchants'
+    merchant = Merchant.new(merchant_params)
+    if merchant.save
+      redirect_to '/merchants'
+    else
+      flash[:error] = merchant.errors.full_messages.join(". ")
+      render :new
+    end
   end
 
   def edit
@@ -22,7 +27,7 @@ class MerchantsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:id])
     if !@merchant.update(new_params)
-      flash[:error] = @merchant.errors.full_messages.join("")
+      flash[:error] = @merchant.errors.full_messages.join(". ")
     else
       @merchant.update(new_params)
     end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -21,7 +21,8 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    if new_params.values.include?("")
+    binding.pry
+    if !@merchant.update(merchant_params)
       @merchant.errors.full_messages
     else
       @merchant.update(merchant_params)
@@ -41,7 +42,7 @@ class MerchantsController < ApplicationController
   end
 
 
-    def new_params
-      binding.pry
-    end
+  def new_params
+    binding.pry
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     </nav>
 
     <% flash.each do |type, message| %>
-      <%= content_tag :div, message, class: type %>
+      <%= message %>
     <% end %>
 
     <%= yield %>

--- a/spec/features/merchant/new_spec.rb
+++ b/spec/features/merchant/new_spec.rb
@@ -30,5 +30,82 @@ RSpec.describe 'New Merchant Creation' do
       expect(current_path).to eq('/merchants')
       expect(page).to have_link(name)
     end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Address', with: "Address"
+      fill_in 'City', with: "City"
+      fill_in 'State', with: "state"
+      fill_in 'Zip', with: 81234
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("Name can't be blank")
+    end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Name', with: "Name"
+      fill_in 'City', with: "City"
+      fill_in 'State', with: "state"
+      fill_in 'Zip', with: 81234
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("Address can't be blank")
+    end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Name', with: "Name"
+      fill_in 'Address', with: "Address"
+      fill_in 'State', with: "state"
+      fill_in 'Zip', with: 81234
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("City can't be blank")
+    end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Name', with: "Name"
+      fill_in 'Address', with: "Address"
+      fill_in 'City', with: "City"
+      fill_in 'Zip', with: 81234
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("State can't be blank")
+    end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Name', with: "Name"
+      fill_in 'Address', with: "Address"
+      fill_in 'City', with: "City"
+      fill_in 'State', with: "state"
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("Zip can't be blank")
+    end
+
+    it 'I cannot create a merchant without required information' do
+      visit '/merchants/new'
+
+      fill_in 'Name', with: "Name"
+      fill_in 'Address', with: "Address"
+      fill_in 'City', with: "City"
+
+      click_button 'Create Merchant'
+
+      expect(page).to have_content("State can't be blank. Zip can't be blank")
+    end
   end
 end

--- a/spec/features/merchant/update_spec.rb
+++ b/spec/features/merchant/update_spec.rb
@@ -40,5 +40,18 @@ RSpec.describe 'Existing Merchant Update' do
         expect(page).to have_content("#{city} #{state} #{zip}")
       end
     end
+
+    it "will flash a message if unable to update merchant properly" do
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Name', with: "name"
+      fill_in 'Address', with: "addressy"
+      fill_in 'City', with: "whoville"
+      fill_in 'State', with: "whotastic"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("You are missing required fields")
+    end
   end
 end

--- a/spec/features/merchant/update_spec.rb
+++ b/spec/features/merchant/update_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe 'Existing Merchant Update' do
       click_button 'Update Merchant'
 
       expect(page).to have_content("City can't be blank")
+
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Name', with: "name"
+      fill_in 'Address', with: "addressy"
+      fill_in 'Zip', with: "81753"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("City can't be blank. State can't be blank")
     end
   end
 end

--- a/spec/features/merchant/update_spec.rb
+++ b/spec/features/merchant/update_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Existing Merchant Update' do
 
       click_button 'Update Merchant'
 
-      expect(page).to have_content("You are missing required fields")
+      expect(page).to have_content("Zip can't be blank")
     end
   end
 end

--- a/spec/features/merchant/update_spec.rb
+++ b/spec/features/merchant/update_spec.rb
@@ -52,6 +52,50 @@ RSpec.describe 'Existing Merchant Update' do
       click_button 'Update Merchant'
 
       expect(page).to have_content("Zip can't be blank")
+
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Name', with: "name"
+      fill_in 'Address', with: "addressy"
+      fill_in 'City', with: "whoville"
+      fill_in 'Zip', with: "81753"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("State can't be blank")
+
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Address', with: "addressy"
+      fill_in 'City', with: "whoville"
+      fill_in 'State', with: "CO"
+      fill_in 'Zip', with: "81753"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("Name can't be blank")
+
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Name', with: "name"
+      fill_in 'City', with: "whoville"
+      fill_in 'State', with: "CO"
+      fill_in 'Zip', with: "81753"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("Address can't be blank")
+
+      visit "/merchants/#{@megan.id}/edit"
+
+      fill_in 'Name', with: "name"
+      fill_in 'Address', with: "addressy"
+      fill_in 'State', with: "CO"
+      fill_in 'Zip', with: "81753"
+
+      click_button 'Update Merchant'
+
+      expect(page).to have_content("City can't be blank")
     end
   end
 end


### PR DESCRIPTION
What does this PR do?

Completes user story #23, (Flash Messages for Merchant Create and Update)
If validations are not met, a message will flash at the user that they are missing required information ("Name can't be blank, zip can't be blank") and if creating, will render the new form again, and if updating, the merchant will not update at all and they are returned to merchant index page.