### PR TITLE
Add remove item from cart, leaves other items in cart untouched

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -17,6 +17,11 @@ class CartController < ApplicationController
     @items = cart.display_cart
   end
 
+  def delete
+    cart.contents.delete(params[:item_id])
+    redirect_to '/cart'
+  end
+
   def destroy
     session.delete(:cart)
     redirect_to '/cart'

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -1,15 +1,16 @@
 <h2>Cart</h2>
 
 <% @items.each do |item,quantity| %>
+<div id="id-<%= item.id %>" class="cart_items">
   <h4>Item: <%= item.name %></h4>
   <p><%= image_tag item.image %></p>
   <p>Merchant: <%= item.merchant.name %></p>
   <p>Price: <%= item.price %></p>
   <p>Subtotal: <%= item.price * quantity %></p>
+  <%= button_to "Remove from Cart", "/cart/#{item.id}", method: :delete %>
 <% end %>
 
 <p>Total: <%= cart.total %></p>
 
 <%= button_to "Empty Cart", '/cart', method: :delete %>
-  <!-- <p>"There are no items in your cart!"</p> -->
 <%= link_to "Checkout", new_order_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get '/cart', to: 'cart#show'
   post '/cart/:item_id', to: 'cart#create'
   delete '/cart', to: 'cart#destroy'
+  delete '/cart/:item_id', to: 'cart#delete'
 
   resources :orders, only: [:new, :create]
 end

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -41,18 +41,36 @@ RSpec.describe 'Cart Show Page' do
         expect(page).to have_content(@ogre.merchant.name)
       end
 
-        it 'I see a link to checkout' do
-          visit "/items/#{@ogre.id}"
-          click_button 'Add to Cart'
+      it 'I see a link to checkout' do
+        visit "/items/#{@ogre.id}"
+        click_button 'Add to Cart'
 
-          visit "/items/#{@giant.id}"
-          click_button 'Add to Cart'
+        visit "/items/#{@giant.id}"
+        click_button 'Add to Cart'
 
-          visit '/cart'
+        visit '/cart'
 
-          click_link "Checkout"
-          expect(current_path).to eq(new_order_path)
+        click_link "Checkout"
+        expect(current_path).to eq(new_order_path)
+      end
+
+      it 'I see a link to remove an item' do
+        visit "/items/#{@ogre.id}"
+        click_button 'Add to Cart'
+
+        visit "/items/#{@giant.id}"
+        click_button 'Add to Cart'
+
+        visit '/cart'
+
+        within "#id-#{@giant.id}", match: :first do
+          click_button "Remove from Cart"
         end
+
+        expect(page).to have_content("Cart: 1")
+        expect(page).to have_content("#{@ogre.name}")
+        expect(page).to have_content("#{@ogre.price}")
       end
     end
   end
+end


### PR DESCRIPTION
What does this PR do?

Users see a button next to each item in their cart to remove. It removes the entire item from the cart's contents, and leaves the other items in the cart