### PR TITLE
Merch destroy control

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -28,6 +28,7 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
+    binding.pry
     if !@merchant.update(new_params)
       flash[:error] = @merchant.errors.full_messages.join(". ")
     else

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -6,7 +6,6 @@ class MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
     @items = @merchant.items
-    # render :layout => false
   end
 
   def new

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -6,7 +6,7 @@ class MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
     @items = @merchant.items
-    render :layout => false
+    # render :layout => false
   end
 
   def new
@@ -28,7 +28,6 @@ class MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    binding.pry
     if !@merchant.update(new_params)
       flash[:error] = @merchant.errors.full_messages.join(". ")
     else

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -17,7 +17,6 @@ class Merchant < ApplicationRecord
 
   def active_orders?
     id = self.items.joins(:orders).pluck(:merchant_id).join('')
-    # binding.pry
     if id == self.id.to_s
       true
     else

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -14,4 +14,14 @@ class Merchant < ApplicationRecord
   def distinct_cities
     self.items.joins(:orders).distinct.pluck(:city)
   end
+
+  def active_orders?
+    id = self.items.joins(:orders).pluck(:merchant_id).join('')
+    # binding.pry
+    if id == self.id.to_s
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -10,7 +10,7 @@
     <h2><%= link_to item.name, "/items/#{item.id}" %></h2>
     <p><%= item.description %></p>
     <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw">
-    <p>Price: <%= (item.price) %></p>
+    <p>Price: <%= number_to_currency(item.price) %></p>
     <p>Sold by: <%= link_to item.merchant.name, "/merchants/#{item.merchant_id}" %>, Inventory: <%= item.inventory %></p>
     <p><%= item.active ? "Active" : "Inactive" %></p>
   </section>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -8,7 +8,6 @@
 <p>Number of Items: <%= @merchant.count_of_items %> </p>
 <p>Average Price Per Item: <%= @merchant.average_price %> </p>
 
-<%= link_to "Items", "/merchants/#{@merchant.id}/items" %>
 
 <%= button_to 'Edit', "/merchants/#{@merchant.id}/edit", method: :get %>
 <%= button_to 'Delete', "/merchants/#{@merchant.id}", method: :delete %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -9,4 +9,6 @@
 <p>Average Price Per Item: <%= @merchant.average_price %> </p>
 
 <%= button_to 'Edit', "/merchants/#{@merchant.id}/edit", method: :get %>
-<%= button_to 'Delete', "/merchants/#{@merchant.id}", method: :delete %>
+<% if !@merchant.active_orders? %>
+  <%= button_to 'Delete', "/merchants/#{@merchant.id}", method: :delete %>
+<% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -8,5 +8,7 @@
 <p>Number of Items: <%= @merchant.count_of_items %> </p>
 <p>Average Price Per Item: <%= @merchant.average_price %> </p>
 
+<%= link_to "Items", "/merchants/#{@merchant.id}/items" %>
+
 <%= button_to 'Edit', "/merchants/#{@merchant.id}/edit", method: :get %>
 <%= button_to 'Delete', "/merchants/#{@merchant.id}", method: :delete %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -8,6 +8,5 @@
 <p>Number of Items: <%= @merchant.count_of_items %> </p>
 <p>Average Price Per Item: <%= @merchant.average_price %> </p>
 
-
 <%= button_to 'Edit', "/merchants/#{@merchant.id}/edit", method: :get %>
 <%= button_to 'Delete', "/merchants/#{@merchant.id}", method: :delete %>

--- a/spec/features/merchant/destroy_spec.rb
+++ b/spec/features/merchant/destroy_spec.rb
@@ -20,8 +20,13 @@ RSpec.describe 'Destroy Existing Merchant' do
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
       @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
       @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
-      
+      @order_1 = @ogre.orders.create!(username: "Adam", address: "123 Street", city: "city", state: "State", zipcode: 12345)
 
+      visit "/merchants/#{@megan.id}"
+      expect(page).to_not have_button 'Delete'
+
+      visit "/merchants/#{@brian.id}"
+      expect(page).to have_button 'Delete'
     end
   end
 end

--- a/spec/features/merchant/destroy_spec.rb
+++ b/spec/features/merchant/destroy_spec.rb
@@ -30,10 +30,3 @@ RSpec.describe 'Destroy Existing Merchant' do
     end
   end
 end
-
-# As a visitor
-# If a merchant has items that have been ordered
-# I can not delete that merchant
-# Either:
-# - there is no button visible for me to delete the merchant
-# - if I click on the delete button, I see a flash message indicating that the merchant can not be deleted.

--- a/spec/features/merchant/destroy_spec.rb
+++ b/spec/features/merchant/destroy_spec.rb
@@ -15,5 +15,20 @@ RSpec.describe 'Destroy Existing Merchant' do
       expect(current_path).to eq('/merchants')
       expect(page).to_not have_content(@brian.name)
     end
+
+    it "there is no button to delete if merchant's items have been ordered" do
+      @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+      @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      
+
+    end
   end
 end
+
+# As a visitor
+# If a merchant has items that have been ordered
+# I can not delete that merchant
+# Either:
+# - there is no button visible for me to delete the merchant
+# - if I click on the delete button, I see a flash message indicating that the merchant can not be deleted.

--- a/spec/features/merchant/update_spec.rb
+++ b/spec/features/merchant/update_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Existing Merchant Update' do
 
       click_button 'Update Merchant'
 
-      expect(page).to have_content("Zip can't be blank")
+      expect(page).to have_content("Zip can't be blank") 
 
       visit "/merchants/#{@megan.id}/edit"
 

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'New Order' do
       expect(page).to have_content("Shipping Information")
 
       within '#shipping' do
-        fill_in "Name", with: 'name'
+        fill_in "Username", with: 'name'
         fill_in "Address", with: 'streeterville'
         fill_in "City", with: 'city'
         fill_in "State", with: 'staterville'

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -40,5 +40,17 @@ RSpec.describe Merchant do
 
       expect(@megan.distinct_cities).to eq([@order_2.city, @order_1.city])
     end
+
+    it ".active_orders?" do
+      @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+      @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @order_1 = @ogre.orders.create!(username: "Adam", address: "123 Street", city: "city", state: "State", zipcode: 12345)
+
+      expect(@megan.active_orders?).to eq(true)
+      expect(@brian.active_orders?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
What does this PR do?

Adds control to merchant destruction. If the merchant has active orders, there is no visible button to the user to delete the merchant. 