### PR TITLE
No item del order

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,4 +17,13 @@ class Item < ApplicationRecord
   def average_review
     reviews.average(:rating).to_i
   end
+
+  def ordered
+    id = orders.pluck(:item_id).join('')
+    if id == self.id.to_s
+      true
+    else
+      false
+    end 
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -39,5 +39,7 @@
 
 <%= link_to 'Update Item', "/items/#{@item.id}/edit" %>
 <%= link_to 'New Review', "/items/#{@item.id}/reviews/new" %>
-<%= link_to 'Delete', "/items/#{@item.id}", method: :delete %>
+<% if !@item.ordered %>
+  <%= link_to 'Delete', "/items/#{@item.id}", method: :delete %>
+<% end %>
 <%= button_to "Add to Cart", "/cart/#{@item.id}" %>

--- a/spec/features/items/delete_spec.rb
+++ b/spec/features/items/delete_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Delete Item' do
         visit "/items/#{@ogre.id}"
         expect(page).to_not have_link('Delete')
 
-        visit "/items/#{@ogre.id}"
+        visit "/items/#{@giant.id}"
         expect(page).to have_link('Delete')
       end
     end

--- a/spec/features/items/delete_spec.rb
+++ b/spec/features/items/delete_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe 'Delete Item' do
         expect(page).to_not have_content(r1)
         expect(page).to_not have_content(r2)
       end
+
+      it "does not show a delete button if item has been ordered" do
+        @order_1 = @ogre.orders.create!(username: "Regina", address: "123 4th St.", city: "Boulder", state: "MI", zipcode: 98765)
+
+        visit "/items/#{@ogre.id}"
+        expect(page).to_not have_link('Delete')
+
+        visit "/items/#{@ogre.id}"
+        expect(page).to have_link('Delete')
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe Item, :type => :model do
       expect(@hippo.average_review).to eq(3)
     end
   end
+
+  describe "ordered" do
+    it "reveal if an item has been ordered in the past" do
+      @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+      @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+      @order_1 = @hippo.orders.create!(username: "Regina", address: "123 4th St.", city: "Boulder", state: "MI", zipcode: 98765)
+
+      expect(@hippo.ordered).to eq(true)
+      expect(@ogre.ordered).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
What does this PR do?

If an item has been ordered, a delete link will not appear on it's show page, but if not, a link will appear to delete.